### PR TITLE
Support integer attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,18 +57,22 @@ function createAttributes(attributes) {
 
   Object.keys(attributes).forEach(function (attribute) {
     var value = attributes[attribute]
-    if (!value && value !== '') return;
+    if (!truthyEnough(value)) return;
 
     value = Array.isArray(value) ? validValues(value)
       : Object(value) === value ? validKeys(value)
       : value
-    if (!value && value !== '') return;
+    if (!truthyEnough(value)) return;
 
     buf += ' ' + attribute
     if (value !== true) buf += '="' + value + '"';
   })
 
   return buf
+}
+
+function truthyEnough (value) {
+  return value || value === 0 || value === '';
 }
 
 function validValues(array) {

--- a/test.js
+++ b/test.js
@@ -36,4 +36,8 @@ assert.equal(el('a', {
   return html + '2'
 }), '<a href="#">2</a>')
 
+assert.equal(el('meta', {
+  property: 0
+}), '<meta property="0">');
+
 console.log('Tests pass!')


### PR DESCRIPTION
This is already sort of supported by the library, the main omission being
that a 0 is interpreted as falsy, and thus is not outputted explicitly as
an attribute value. Loosens the truthiness check when checking an attribute value.